### PR TITLE
updating chapter 2 notebook based on TE comments

### DIFF
--- a/book/chapter 2/Chapter_2_Primer_on_Probability_Modeling.ipynb
+++ b/book/chapter 2/Chapter_2_Primer_on_Probability_Modeling.ipynb
@@ -17,58 +17,11 @@
    "metadata": {
     "id": "98ENU9Vy1KK7"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: pgmpy==0.1.24 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (0.1.24)\n",
-      "Requirement already satisfied: networkx in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (3.2.1)\n",
-      "Requirement already satisfied: numpy in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (1.26.4)\n",
-      "Requirement already satisfied: scipy in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (1.12.0)\n",
-      "Requirement already satisfied: scikit-learn in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (1.4.0)\n",
-      "Requirement already satisfied: pandas in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (2.2.0)\n",
-      "Requirement already satisfied: pyparsing in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (3.1.1)\n",
-      "Requirement already satisfied: torch in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (2.2.0)\n",
-      "Requirement already satisfied: statsmodels in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (0.14.1)\n",
-      "Requirement already satisfied: tqdm in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (4.66.2)\n",
-      "Requirement already satisfied: joblib in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (1.3.2)\n",
-      "Requirement already satisfied: opt-einsum in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (3.3.0)\n",
-      "Requirement already satisfied: python-dateutil>=2.8.2 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pandas->pgmpy==0.1.24) (2.8.2)\n",
-      "Requirement already satisfied: pytz>=2020.1 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pandas->pgmpy==0.1.24) (2024.1)\n",
-      "Requirement already satisfied: tzdata>=2022.7 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pandas->pgmpy==0.1.24) (2023.4)\n",
-      "Requirement already satisfied: threadpoolctl>=2.0.0 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from scikit-learn->pgmpy==0.1.24) (3.2.0)\n",
-      "Requirement already satisfied: patsy>=0.5.4 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from statsmodels->pgmpy==0.1.24) (0.5.6)\n",
-      "Requirement already satisfied: packaging>=21.3 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from statsmodels->pgmpy==0.1.24) (23.2)\n",
-      "Requirement already satisfied: filelock in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch->pgmpy==0.1.24) (3.13.1)\n",
-      "Requirement already satisfied: typing-extensions>=4.8.0 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch->pgmpy==0.1.24) (4.9.0)\n",
-      "Requirement already satisfied: sympy in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch->pgmpy==0.1.24) (1.12)\n",
-      "Requirement already satisfied: jinja2 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch->pgmpy==0.1.24) (3.1.3)\n",
-      "Requirement already satisfied: fsspec in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch->pgmpy==0.1.24) (2024.2.0)\n",
-      "Requirement already satisfied: six in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from patsy>=0.5.4->statsmodels->pgmpy==0.1.24) (1.16.0)\n",
-      "Requirement already satisfied: MarkupSafe>=2.0 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from jinja2->torch->pgmpy==0.1.24) (2.1.5)\n",
-      "Requirement already satisfied: mpmath>=0.19 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from sympy->torch->pgmpy==0.1.24) (1.3.0)\n",
-      "Requirement already satisfied: pyro-ppl==1.8.6 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (1.8.6)\n",
-      "Requirement already satisfied: numpy>=1.7 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pyro-ppl==1.8.6) (1.26.4)\n",
-      "Requirement already satisfied: opt-einsum>=2.3.2 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pyro-ppl==1.8.6) (3.3.0)\n",
-      "Requirement already satisfied: pyro-api>=0.1.1 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pyro-ppl==1.8.6) (0.1.2)\n",
-      "Requirement already satisfied: torch>=1.11.0 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pyro-ppl==1.8.6) (2.2.0)\n",
-      "Requirement already satisfied: tqdm>=4.36 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pyro-ppl==1.8.6) (4.66.2)\n",
-      "Requirement already satisfied: filelock in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch>=1.11.0->pyro-ppl==1.8.6) (3.13.1)\n",
-      "Requirement already satisfied: typing-extensions>=4.8.0 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch>=1.11.0->pyro-ppl==1.8.6) (4.9.0)\n",
-      "Requirement already satisfied: sympy in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch>=1.11.0->pyro-ppl==1.8.6) (1.12)\n",
-      "Requirement already satisfied: networkx in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch>=1.11.0->pyro-ppl==1.8.6) (3.2.1)\n",
-      "Requirement already satisfied: jinja2 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch>=1.11.0->pyro-ppl==1.8.6) (3.1.3)\n",
-      "Requirement already satisfied: fsspec in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch>=1.11.0->pyro-ppl==1.8.6) (2024.2.0)\n",
-      "Requirement already satisfied: MarkupSafe>=2.0 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from jinja2->torch>=1.11.0->pyro-ppl==1.8.6) (2.1.5)\n",
-      "Requirement already satisfied: mpmath>=0.19 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from sympy->torch>=1.11.0->pyro-ppl==1.8.6) (1.3.0)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# For stability of this notebook, I install the versions of pgmpy and pyro that were current at the time of writing.\n",
-    "!pip install pgmpy==0.1.24\n",
-    "!pip install pyro-ppl==1.8.6"
+    "#!pip install pgmpy==0.1.24\n",
+    "#!pip install pyro-ppl==1.8.6"
    ]
   },
   {

--- a/book/chapter 2/Chapter_2_Primer_on_Probability_Modeling.ipynb
+++ b/book/chapter 2/Chapter_2_Primer_on_Probability_Modeling.ipynb
@@ -1,2642 +1,2461 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "widgets": {
-      "application/vnd.jupyter.widget-state+json": {
-        "e3d150d5dd434fee8b44c8234ca6f0bb": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_ab7cefa9ca604bd1875aac6af7ee80d6",
-              "IPY_MODEL_03523d6eaab149659f1f940c746c1a1a",
-              "IPY_MODEL_8687a49bb8454f0592c80a26b3197b83"
-            ],
-            "layout": "IPY_MODEL_b9f872f2e69a4d52a6bc5a35eb65f8cb"
-          }
-        },
-        "ab7cefa9ca604bd1875aac6af7ee80d6": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_6de980a54d33458cad46a859ddd9827b",
-            "placeholder": "​",
-            "style": "IPY_MODEL_54b15c7e8a004d70ac43f0d671259a70",
-            "value": "Generating for node: Y: 100%"
-          }
-        },
-        "03523d6eaab149659f1f940c746c1a1a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_d7aeb5ae6cab45299006a8edb58b0e5a",
-            "max": 3,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_16f74741d4af4d36a79f319d9e800ee4",
-            "value": 3
-          }
-        },
-        "8687a49bb8454f0592c80a26b3197b83": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_4ae256d707414f999cd8db3cce2b7e86",
-            "placeholder": "​",
-            "style": "IPY_MODEL_b0c5861eb58341848f7a09f8bb429f9d",
-            "value": " 3/3 [00:00&lt;00:00,  7.24it/s]"
-          }
-        },
-        "b9f872f2e69a4d52a6bc5a35eb65f8cb": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "6de980a54d33458cad46a859ddd9827b": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "54b15c7e8a004d70ac43f0d671259a70": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "d7aeb5ae6cab45299006a8edb58b0e5a": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "16f74741d4af4d36a79f319d9e800ee4": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "4ae256d707414f999cd8db3cce2b7e86": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "b0c5861eb58341848f7a09f8bb429f9d": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "ff2d1e780eb441ec8bc910c2dba5da2c": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_78cffc8c3acc4c7a9f062bab35547ab0",
-              "IPY_MODEL_39ceb682850d4efea7bfbeaf81f2178d",
-              "IPY_MODEL_471d8046ab1a48ab9097be929f9f6360"
-            ],
-            "layout": "IPY_MODEL_a8e5a12719314897af9140a1887c1150"
-          }
-        },
-        "78cffc8c3acc4c7a9f062bab35547ab0": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_2b4d278c6e8d4a51a8275b55938cd0ad",
-            "placeholder": "​",
-            "style": "IPY_MODEL_fe987a699e484adebca1231b6d03d367",
-            "value": "Generating for node: Y: 100%"
-          }
-        },
-        "39ceb682850d4efea7bfbeaf81f2178d": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_60a12d6cfdb24aae8c7dcddaad9a3f24",
-            "max": 3,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_b6344c56244844669b5d04128557a1ee",
-            "value": 3
-          }
-        },
-        "471d8046ab1a48ab9097be929f9f6360": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_1ac9ec0ead7049688ab26dc09ec6cdfe",
-            "placeholder": "​",
-            "style": "IPY_MODEL_aa00d2f977c2438cb293bafcbcbee6eb",
-            "value": " 3/3 [00:00&lt;00:00, 30.00it/s]"
-          }
-        },
-        "a8e5a12719314897af9140a1887c1150": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "2b4d278c6e8d4a51a8275b55938cd0ad": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "fe987a699e484adebca1231b6d03d367": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "60a12d6cfdb24aae8c7dcddaad9a3f24": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "b6344c56244844669b5d04128557a1ee": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "1ac9ec0ead7049688ab26dc09ec6cdfe": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "aa00d2f977c2438cb293bafcbcbee6eb": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "e3b63a1a0e2446a992feac85a7778977": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HBoxModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HBoxView",
-            "box_style": "",
-            "children": [
-              "IPY_MODEL_7f2c7346c9634edcb8bf5f7bb491471e",
-              "IPY_MODEL_d330ceae733f4dc49ce79057b23bdf0c",
-              "IPY_MODEL_cdf929165c5049a28c99a1de9d31f728"
-            ],
-            "layout": "IPY_MODEL_9213ec21924e4e52ab9d78efa8f390da"
-          }
-        },
-        "7f2c7346c9634edcb8bf5f7bb491471e": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_8d0f3c4f6af74b3e9e5c05e1e84f4189",
-            "placeholder": "​",
-            "style": "IPY_MODEL_3adc185fc25348a2ab2e983b47456fca",
-            "value": "Generating for node: Y: 100%"
-          }
-        },
-        "d330ceae733f4dc49ce79057b23bdf0c": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "FloatProgressModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "ProgressView",
-            "bar_style": "success",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_6ef7e322bdff42618162b8bc7b8be89b",
-            "max": 3,
-            "min": 0,
-            "orientation": "horizontal",
-            "style": "IPY_MODEL_f03e769372674f4d83ffdc5da99f12dc",
-            "value": 3
-          }
-        },
-        "cdf929165c5049a28c99a1de9d31f728": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_dom_classes": [],
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "HTMLModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/controls",
-            "_view_module_version": "1.5.0",
-            "_view_name": "HTMLView",
-            "description": "",
-            "description_tooltip": null,
-            "layout": "IPY_MODEL_d6467974ef1e4ead8f2516e1202ebb22",
-            "placeholder": "​",
-            "style": "IPY_MODEL_2ed32b1e8fba4db6b720a80997101185",
-            "value": " 3/3 [00:00&lt;00:00, 36.60it/s]"
-          }
-        },
-        "9213ec21924e4e52ab9d78efa8f390da": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "8d0f3c4f6af74b3e9e5c05e1e84f4189": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "3adc185fc25348a2ab2e983b47456fca": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        },
-        "6ef7e322bdff42618162b8bc7b8be89b": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "f03e769372674f4d83ffdc5da99f12dc": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "ProgressStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "bar_color": null,
-            "description_width": ""
-          }
-        },
-        "d6467974ef1e4ead8f2516e1202ebb22": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.2.0",
-            "_model_name": "LayoutModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "LayoutView",
-            "align_content": null,
-            "align_items": null,
-            "align_self": null,
-            "border": null,
-            "bottom": null,
-            "display": null,
-            "flex": null,
-            "flex_flow": null,
-            "grid_area": null,
-            "grid_auto_columns": null,
-            "grid_auto_flow": null,
-            "grid_auto_rows": null,
-            "grid_column": null,
-            "grid_gap": null,
-            "grid_row": null,
-            "grid_template_areas": null,
-            "grid_template_columns": null,
-            "grid_template_rows": null,
-            "height": null,
-            "justify_content": null,
-            "justify_items": null,
-            "left": null,
-            "margin": null,
-            "max_height": null,
-            "max_width": null,
-            "min_height": null,
-            "min_width": null,
-            "object_fit": null,
-            "object_position": null,
-            "order": null,
-            "overflow": null,
-            "overflow_x": null,
-            "overflow_y": null,
-            "padding": null,
-            "right": null,
-            "top": null,
-            "visibility": null,
-            "width": null
-          }
-        },
-        "2ed32b1e8fba4db6b720a80997101185": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_model_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_model_name": "DescriptionStyleModel",
-            "_view_count": null,
-            "_view_module": "@jupyter-widgets/base",
-            "_view_module_version": "1.2.0",
-            "_view_name": "StyleView",
-            "description_width": ""
-          }
-        }
-      }
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0E34xvN8et9z"
+   },
+   "source": [
+    "# Chapter 2 - Primer on Probability Modeling\n",
+    "\n",
+    "The notebook is a code companion to chapter 2 of the book [Causal Machine Learning](https://www.manning.com/books/causal-machine-learning) by Robert Osazuwa Ness."
+   ]
   },
-  "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "98ENU9Vy1KK7"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "source": [
-        "# Chapter 2 - Primer on Probability Modeling\n",
-        "\n",
-        "The notebook is a code companion to chapter 2 of the book [Causal Machine Learning](https://www.manning.com/books/causal-machine-learning) by Robert Osazuwa Ness."
-      ],
-      "metadata": {
-        "id": "0E34xvN8et9z"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "#!pip install pgmpy\n",
-        "#!pip install pyro-ppl"
-      ],
-      "metadata": {
-        "id": "98ENU9Vy1KK7"
-      },
-      "execution_count": 23,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Implementing a discrete distribution table in pgmpy\n"
-      ],
-      "metadata": {
-        "id": "HcycIJX81Pmm"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import pgmpy\n",
-        "from pgmpy.factors.discrete import DiscreteFactor\n",
-        "dist = DiscreteFactor(\n",
-        "    variables=[\"X\"],    #A\n",
-        "    cardinality=[3],    #B\n",
-        "    values=[.45, .30, .25],    #C\n",
-        "    state_names= {'X': ['1', '2', '3']}    #D\n",
-        ")\n",
-        "\n",
-        "#A A list of the names of the variables in the factor\n",
-        "#B The cardinality (number of possible outcomes of each variable in the factor\n",
-        "#C The values each variable in the factor can take\n",
-        "#D Dictionary where the key is the variable name and the value is a list of the names of that variable’s outcomes\n",
-        "\n",
-        "print(dist)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "qzPPspx4eufQ",
-        "outputId": "c7e9e446-6297-4100-ade1-c0ec0bbc8f6e"
-      },
-      "execution_count": 24,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "+------+----------+\n",
-            "| X    |   phi(X) |\n",
-            "+======+==========+\n",
-            "| X(1) |   0.4500 |\n",
-            "+------+----------+\n",
-            "| X(2) |   0.3000 |\n",
-            "+------+----------+\n",
-            "| X(3) |   0.2500 |\n",
-            "+------+----------+\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "“phi(X)” is the probability value assigned to each outcome of X.  One thing to note is that these phi values don’t need to sum to one.  For example, I can multiple each probability value by one hundred as follows."
-      ],
-      "metadata": {
-        "id": "A-D3GoX4fN52"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "dist = DiscreteFactor(\n",
-        "    variables=[\"X\"],\n",
-        "    cardinality=[3],\n",
-        "    values=[45, 30, 25],\n",
-        "    state_names= {'X': ['1', '2', '3']}\n",
-        ")\n",
-        "\n",
-        "print(dist)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "G8bwqFF2fDYb",
-        "outputId": "6c40b86d-6857-4f85-c04f-93df3d3ee951"
-      },
-      "execution_count": 25,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "+------+----------+\n",
-            "| X    |   phi(X) |\n",
-            "+======+==========+\n",
-            "| X(1) |  45.0000 |\n",
-            "+------+----------+\n",
-            "| X(2) |  30.0000 |\n",
-            "+------+----------+\n",
-            "| X(3) |  25.0000 |\n",
-            "+------+----------+\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "pgmpy relaxes the constraint to sum to one is because the relaxation is useful in some algorithms.  We can always normalize to obtain proper probability values. "
-      ],
-      "metadata": {
-        "id": "tdAVY-hpfa_N"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# Normalize takes phi values for each outcome and divides them by their sum to get a probability. \n",
-        "dist.normalize()\n",
-        "\n",
-        "print(dist)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "gA1aBQajfZk7",
-        "outputId": "e6574d2a-c34d-4234-e915-d91e7bfb8b4e"
-      },
-      "execution_count": 26,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "+------+----------+\n",
-            "| X    |   phi(X) |\n",
-            "+======+==========+\n",
-            "| X(1) |   0.4500 |\n",
-            "+------+----------+\n",
-            "| X(2) |   0.3000 |\n",
-            "+------+----------+\n",
-            "| X(3) |   0.2500 |\n",
-            "+------+----------+\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Modeling a joint distribution in pgmpy"
-      ],
-      "metadata": {
-        "id": "HDS9Juwtf6tY"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "joint = DiscreteFactor(\n",
-        "    variables=['X', 'Y'],   #A\n",
-        "    cardinality=[3, 2],    #B\n",
-        "    values=[.25, .20, .20, .10, .15, .10],   #C \n",
-        "    state_names= {    \n",
-        "        'X': ['1', '2', '3'],    #C\n",
-        "        'Y': ['0', '1']    #C\n",
-        "    }\n",
-        ")\n",
-        "\n",
-        "#A Now we have two variables instead of one.\n",
-        "#B X has 3 outcomes, Y has 2.\n",
-        "#C You can look at the printed output to see how the values are ordered of values.\n",
-        "#D Now there are two variables, so we name the outcomes for both variables.\n",
-        "\n",
-        "print(joint)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "TXRN08jSfqCl",
-        "outputId": "c75be905-1d76-456b-8b47-7a3b0e782b19"
-      },
-      "execution_count": 27,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "+------+------+------------+\n",
-            "| X    | Y    |   phi(X,Y) |\n",
-            "+======+======+============+\n",
-            "| X(1) | Y(0) |     0.2500 |\n",
-            "+------+------+------------+\n",
-            "| X(1) | Y(1) |     0.2000 |\n",
-            "+------+------+------------+\n",
-            "| X(2) | Y(0) |     0.2000 |\n",
-            "+------+------+------------+\n",
-            "| X(2) | Y(1) |     0.1000 |\n",
-            "+------+------+------------+\n",
-            "| X(3) | Y(0) |     0.1500 |\n",
-            "+------+------+------------+\n",
-            "| X(3) | Y(1) |     0.1000 |\n",
-            "+------+------+------------+\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "The marginalize method will accomplish summing over the specified variables for us.\n"
-      ],
-      "metadata": {
-        "id": "LmU5Mf5mgO-H"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "print(joint.marginalize(variables=['Y'], inplace=False))\n",
-        "print(joint.marginalize(variables=['X'], inplace=False))"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "5FQ1-LtqhoRq",
-        "outputId": "db62723e-e123-49df-9653-5e0f5359633c"
-      },
-      "execution_count": 28,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "+------+----------+\n",
-            "| X    |   phi(X) |\n",
-            "+======+==========+\n",
-            "| X(1) |   0.4500 |\n",
-            "+------+----------+\n",
-            "| X(2) |   0.3000 |\n",
-            "+------+----------+\n",
-            "| X(3) |   0.2500 |\n",
-            "+------+----------+\n",
-            "+------+----------+\n",
-            "| Y    |   phi(Y) |\n",
-            "+======+==========+\n",
-            "| Y(0) |   0.6000 |\n",
-            "+------+----------+\n",
-            "| Y(1) |   0.4000 |\n",
-            "+------+----------+\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "We can divide two factors to calculate conditional probabilities."
-      ],
-      "metadata": {
-        "id": "3DQjnxI9ZFaZ"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "print(joint / dist)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "6pHGwacShqn7",
-        "outputId": "3358b982-56fd-4a82-c347-2c0744ab3491"
-      },
-      "execution_count": 29,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "+------+------+------------+\n",
-            "| X    | Y    |   phi(X,Y) |\n",
-            "+======+======+============+\n",
-            "| X(1) | Y(0) |     0.5556 |\n",
-            "+------+------+------------+\n",
-            "| X(1) | Y(1) |     0.4444 |\n",
-            "+------+------+------------+\n",
-            "| X(2) | Y(0) |     0.6667 |\n",
-            "+------+------+------------+\n",
-            "| X(2) | Y(1) |     0.3333 |\n",
-            "+------+------+------------+\n",
-            "| X(3) | Y(0) |     0.6000 |\n",
-            "+------+------+------------+\n",
-            "| X(3) | Y(1) |     0.4000 |\n",
-            "+------+------+------------+\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "However, the more direct way in pgmpy to specify a conditional probability distribution table is with the TabularCPD class:"
-      ],
-      "metadata": {
-        "id": "lNje9Z9IZBY2"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from pgmpy.factors.discrete.CPD import TabularCPD\n",
-        "PYgivenX = TabularCPD(\n",
-        "    variable='Y',    #A\n",
-        "    variable_card=2,    #B\n",
-        "    values=[\n",
-        "        [.25/.45, .20/.30, .15/.25],    #C\n",
-        "        [.20/.45, .10/.30, .10/.25],    #C\n",
-        "    ], \n",
-        "    evidence=['X'],\n",
-        "    evidence_card=[3],\n",
-        "    state_names = {\n",
-        "        'X': ['1', '2', '3'],\n",
-        "        'Y': ['0', '1']\n",
-        "    })\n",
-        "\n",
-        "#A Conditional distribution has one variable instead of DiscreteFactor’s list of variables.\n",
-        "#B variable_card is the cardinality of Y\n",
-        "#C Elements of the list correspond to outcomes for Y. Elements of each list correspond to elements of X.\n",
-        "\n",
-        "print(PYgivenX)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "4eUC_8dBZPCW",
-        "outputId": "2bc36855-5494-4ff3-c94f-560ce5782953"
-      },
-      "execution_count": 30,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "+------+--------------------+---------------------+------+\n",
-            "| X    | X(1)               | X(2)                | X(3) |\n",
-            "+------+--------------------+---------------------+------+\n",
-            "| Y(0) | 0.5555555555555556 | 0.6666666666666667  | 0.6  |\n",
-            "+------+--------------------+---------------------+------+\n",
-            "| Y(1) | 0.4444444444444445 | 0.33333333333333337 | 0.4  |\n",
-            "+------+--------------------+---------------------+------+\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Canonical parameters in Pyro"
-      ],
-      "metadata": {
-        "id": "FyDHZZDFZy80"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import torch\n",
-        "from pyro.distributions import Bernoulli, Categorical, Gamma, Normal\n",
-        "\n",
-        "# The categorical distribution takes a list of probability values, each value corresponding to an outcome.\n",
-        "print(Categorical(probs=torch.tensor([.45, .30, .25])))\n",
-        "print(Normal(loc=0.0, scale=1.0))\n",
-        "print(Bernoulli(probs=0.4))\n",
-        "print(Gamma(concentration=1.0, rate=2.0))\n",
-        "\n",
-        "bern = Bernoulli(0.4)\n",
-        "lprob = bern.log_prob(torch.tensor(1.0))\n",
-        "\n",
-        "import math\n",
-        "print(math.exp(lprob))\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "UG_fOPwiZokM",
-        "outputId": "22b119be-e759-499f-a909-bb9049cb99e7"
-      },
-      "execution_count": 31,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Categorical(probs: torch.Size([3]))\n",
-            "Normal(loc: 0.0, scale: 1.0)\n",
-            "Bernoulli(probs: 0.4000000059604645)\n",
-            "Gamma(concentration: 1.0, rate: 2.0)\n",
-            "0.3999999887335489\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Simulating from DiscreteFactor in pgmpy and Pyro"
-      ],
-      "metadata": {
-        "id": "4sKd5PbLbvtu"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from pgmpy.factors.discrete import DiscreteFactor\n",
-        "dist = DiscreteFactor(\n",
-        "    variables=[\"X\"],\n",
-        "    cardinality=[3],\n",
-        "    values=[.45, .30, .25],\n",
-        "    state_names= {'X': ['1', '2', '3']}\n",
-        ")\n",
-        "\n",
-        "# n is the number of instances you wish to generate\n",
-        "dist.sample(n=1)\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 81
-        },
-        "id": "lOqDNVM8buUH",
-        "outputId": "76780e33-64d5-4dfd-937f-4f0dad0480eb"
-      },
-      "execution_count": 32,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "   X\n",
-              "0  3"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-9d44de6f-ca56-4b8c-bd62-0af720dbd5af\">\n",
-              "    <div class=\"colab-df-container\">\n",
-              "      <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>X</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>3</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-9d44de6f-ca56-4b8c-bd62-0af720dbd5af')\"\n",
-              "              title=\"Convert this dataframe to an interactive table.\"\n",
-              "              style=\"display:none;\">\n",
-              "        \n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "       width=\"24px\">\n",
-              "    <path d=\"M0 0h24v24H0V0z\" fill=\"none\"/>\n",
-              "    <path d=\"M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z\"/><path d=\"M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z\"/>\n",
-              "  </svg>\n",
-              "      </button>\n",
-              "      \n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      flex-wrap:wrap;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "      <script>\n",
-              "        const buttonEl =\n",
-              "          document.querySelector('#df-9d44de6f-ca56-4b8c-bd62-0af720dbd5af button.colab-df-convert');\n",
-              "        buttonEl.style.display =\n",
-              "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-9d44de6f-ca56-4b8c-bd62-0af720dbd5af');\n",
-              "          const dataTable =\n",
-              "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                     [key], {});\n",
-              "          if (!dataTable) return;\n",
-              "\n",
-              "          const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "            '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "            + ' to learn more about interactive tables.';\n",
-              "          element.innerHTML = '';\n",
-              "          dataTable['output_type'] = 'display_data';\n",
-              "          await google.colab.output.renderOutput(dataTable, element);\n",
-              "          const docLink = document.createElement('div');\n",
-              "          docLink.innerHTML = docLinkHtml;\n",
-              "          element.appendChild(docLink);\n",
-              "        }\n",
-              "      </script>\n",
-              "    </div>\n",
-              "  </div>\n",
-              "  "
-            ]
-          },
-          "metadata": {},
-          "execution_count": 32
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "joint = DiscreteFactor(\n",
-        "    variables=['X', 'Y'],\n",
-        "    cardinality=[3, 2],\n",
-        "    values=[.25, .20, .20, .10, .15, .10],\n",
-        "    state_names= {\n",
-        "        'X': ['1', '2', '3'],\n",
-        "        'Y': ['0', '1']\n",
-        "    }\n",
-        ")\n",
-        "\n",
-        "joint.sample(n=1)\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 81
-        },
-        "id": "3gFe94BJb904",
-        "outputId": "ef28fd3f-572c-4078-abea-7c9a581ad579"
-      },
-      "execution_count": 33,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "   X  Y\n",
-              "0  1  0"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-905152e4-ebd8-40fb-8c87-e4b3ae6c1e39\">\n",
-              "    <div class=\"colab-df-container\">\n",
-              "      <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>X</th>\n",
-              "      <th>Y</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-905152e4-ebd8-40fb-8c87-e4b3ae6c1e39')\"\n",
-              "              title=\"Convert this dataframe to an interactive table.\"\n",
-              "              style=\"display:none;\">\n",
-              "        \n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "       width=\"24px\">\n",
-              "    <path d=\"M0 0h24v24H0V0z\" fill=\"none\"/>\n",
-              "    <path d=\"M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z\"/><path d=\"M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z\"/>\n",
-              "  </svg>\n",
-              "      </button>\n",
-              "      \n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      flex-wrap:wrap;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "      <script>\n",
-              "        const buttonEl =\n",
-              "          document.querySelector('#df-905152e4-ebd8-40fb-8c87-e4b3ae6c1e39 button.colab-df-convert');\n",
-              "        buttonEl.style.display =\n",
-              "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-905152e4-ebd8-40fb-8c87-e4b3ae6c1e39');\n",
-              "          const dataTable =\n",
-              "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                     [key], {});\n",
-              "          if (!dataTable) return;\n",
-              "\n",
-              "          const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "            '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "            + ' to learn more about interactive tables.';\n",
-              "          element.innerHTML = '';\n",
-              "          dataTable['output_type'] = 'display_data';\n",
-              "          await google.colab.output.renderOutput(dataTable, element);\n",
-              "          const docLink = document.createElement('div');\n",
-              "          docLink.innerHTML = docLinkHtml;\n",
-              "          element.appendChild(docLink);\n",
-              "        }\n",
-              "      </script>\n",
-              "    </div>\n",
-              "  </div>\n",
-              "  "
-            ]
-          },
-          "metadata": {},
-          "execution_count": 33
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Canonical distributions in pyro also use a method with sample method."
-      ],
-      "metadata": {
-        "id": "jL-oWJuRcNFI"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import torch\n",
-        "from pyro.distributions import Categorical\n",
-        "Categorical(probs=torch.tensor([.45, .30, .25])).sample()\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "LvvQ_jv1cJLZ",
-        "outputId": "41e6e552-3a8b-4d6c-f758-4dd9cf91361e"
-      },
-      "execution_count": 34,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "tensor(1)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 34
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Creating a random process in pgmpy and pyro."
-      ],
-      "metadata": {
-        "id": "MtP49-FcdZ0G"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "from pgmpy.factors.discrete.CPD import TabularCPD\n",
-        "from pgmpy.models import BayesianNetwork\n",
-        "from pgmpy.sampling import BayesianModelSampling\n",
-        "\n",
-        "PZ = TabularCPD(\n",
-        "    variable='Z', \n",
-        "    variable_card=2,\n",
-        "    values=[[.65], [.35]],\n",
-        "    state_names = {\n",
-        "        'Z': ['0', '1']\n",
-        "    })\n",
-        "\n",
-        "PXgivenZ = TabularCPD(\n",
-        "    variable='X',\n",
-        "    variable_card=2,\n",
-        "    values=[\n",
-        "        [.8, .6],\n",
-        "        [.2, .4],\n",
-        "    ],\n",
-        "    evidence=['Z'],\n",
-        "    evidence_card=[2],\n",
-        "    state_names = {\n",
-        "        'X': ['0', '1'],\n",
-        "        'Z': ['0', '1']\n",
-        "    })\n",
-        "\n",
-        "PYgivenX = TabularCPD(\n",
-        "    variable='Y',\n",
-        "    variable_card=3,\n",
-        "    values=[\n",
-        "        [.1, .8],\n",
-        "        [.2, .1],\n",
-        "        [.7, .1],\n",
-        "    ],\n",
-        "    evidence=['X'],\n",
-        "    evidence_card=[2],\n",
-        "    state_names = {\n",
-        "        'Y': ['1', '2', '3'],\n",
-        "        'X': ['0', '1']\n",
-        "    })\n",
-        "\n",
-        "model = BayesianNetwork([('Z', 'X'), ('X', 'Y')])    #D\n",
-        "model.add_cpds(PZ, PXgivenZ, PYgivenX)\n",
-        "\n",
-        "generator = BayesianModelSampling(model)    #F\n",
-        "generator.forward_sample(size=1)\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 113,
-          "referenced_widgets": [
-            "e3d150d5dd434fee8b44c8234ca6f0bb",
-            "ab7cefa9ca604bd1875aac6af7ee80d6",
-            "03523d6eaab149659f1f940c746c1a1a",
-            "8687a49bb8454f0592c80a26b3197b83",
-            "b9f872f2e69a4d52a6bc5a35eb65f8cb",
-            "6de980a54d33458cad46a859ddd9827b",
-            "54b15c7e8a004d70ac43f0d671259a70",
-            "d7aeb5ae6cab45299006a8edb58b0e5a",
-            "16f74741d4af4d36a79f319d9e800ee4",
-            "4ae256d707414f999cd8db3cce2b7e86",
-            "b0c5861eb58341848f7a09f8bb429f9d"
-          ]
-        },
-        "id": "ix9uF77qcW-D",
-        "outputId": "d43b9877-6843-4c1a-be82-fcab6acf8c8a"
-      },
-      "execution_count": 13,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "  0%|          | 0/3 [00:00<?, ?it/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "e3d150d5dd434fee8b44c8234ca6f0bb"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "   Z  X  Y\n",
-              "0  0  0  3"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-fc0f50ca-0261-46e3-b95c-481645a2f6cf\">\n",
-              "    <div class=\"colab-df-container\">\n",
-              "      <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>Z</th>\n",
-              "      <th>X</th>\n",
-              "      <th>Y</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>3</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-fc0f50ca-0261-46e3-b95c-481645a2f6cf')\"\n",
-              "              title=\"Convert this dataframe to an interactive table.\"\n",
-              "              style=\"display:none;\">\n",
-              "        \n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "       width=\"24px\">\n",
-              "    <path d=\"M0 0h24v24H0V0z\" fill=\"none\"/>\n",
-              "    <path d=\"M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z\"/><path d=\"M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z\"/>\n",
-              "  </svg>\n",
-              "      </button>\n",
-              "      \n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      flex-wrap:wrap;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "      <script>\n",
-              "        const buttonEl =\n",
-              "          document.querySelector('#df-fc0f50ca-0261-46e3-b95c-481645a2f6cf button.colab-df-convert');\n",
-              "        buttonEl.style.display =\n",
-              "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-fc0f50ca-0261-46e3-b95c-481645a2f6cf');\n",
-              "          const dataTable =\n",
-              "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                     [key], {});\n",
-              "          if (!dataTable) return;\n",
-              "\n",
-              "          const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "            '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "            + ' to learn more about interactive tables.';\n",
-              "          element.innerHTML = '';\n",
-              "          dataTable['output_type'] = 'display_data';\n",
-              "          await google.colab.output.renderOutput(dataTable, element);\n",
-              "          const docLink = document.createElement('div');\n",
-              "          docLink.innerHTML = docLinkHtml;\n",
-              "          element.appendChild(docLink);\n",
-              "        }\n",
-              "      </script>\n",
-              "    </div>\n",
-              "  </div>\n",
-              "  "
-            ]
-          },
-          "metadata": {},
-          "execution_count": 13
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Working with combinations of canonical distributions in Pyro"
-      ],
-      "metadata": {
-        "id": "Mx1_KI7AdOsm"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import torch\n",
-        "from pyro.distributions import Bernoulli, Poisson, Gamma\n",
-        "\n",
-        "# Represent P(Z) with a Gamma distribution, and sample z.\n",
-        "z = Gamma(7.5, 1.0).sample()    #A\n",
-        "# Represent P(X|Z=z) with a Poisson distribution with location parameter z, and sample x.\n",
-        "x = Poisson(z).sample()    #B\n",
-        "# Represent P(Y|X=x) with a Bernoulli distribution. The probability parameter is a function of y.\n",
-        "y = Bernoulli(x / (5+x)).sample()    #C\n",
-        "\n",
-        "print(z, x, y)\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "92aWaC4qhcv0",
-        "outputId": "796c3444-b7da-4b4d-96f8-7f11018a07f2"
-      },
-      "execution_count": 14,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "tensor(4.0089) tensor(5.) tensor(1.)\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Random processes with nuanced control flow in Pyro"
-      ],
-      "metadata": {
-        "id": "4eYUHJFUj7cp"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import torch\n",
-        "from pyro.distributions import Bernoulli, Poisson, Gamma\n",
-        "z = Gamma(7.5, 1.0).sample()\n",
-        "x = Poisson(z).sample()\n",
-        "# y is calculated as a sum of random coin flips.\n",
-        "# y is generated from P(Y|X=x) because the number of flips depends on x.\n",
-        "y = torch.tensor(0.0)\n",
-        "for i in range(int(x)):\n",
-        "    y += Bernoulli(.5).sample()    \n"
-      ],
-      "metadata": {
-        "id": "IrGBg5gYj80N"
-      },
-      "execution_count": 15,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Using functions for random processes and pyro.sample "
-      ],
-      "metadata": {
-        "id": "t9apo5zPlsz-"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import torch\n",
-        "import pyro\n",
-        "def random_process():\n",
-        "    z = pyro.sample(\"z\", Gamma(7.5, 1.0))\n",
-        "    x = pyro.sample(\"x\", Poisson(z))\n",
-        "    y = torch.tensor(0.0)\n",
-        "    for i in range(int(x)):\n",
-        "        y += pyro.sample(f\"y{i}\", Bernoulli(.5))    #A\n",
-        "    return y\n",
-        "\n",
-        "generated_samples = generator.forward_sample(size=100)\n",
-        "generated_samples['Y'].apply(int).mean()\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 67,
-          "referenced_widgets": [
-            "ff2d1e780eb441ec8bc910c2dba5da2c",
-            "78cffc8c3acc4c7a9f062bab35547ab0",
-            "39ceb682850d4efea7bfbeaf81f2178d",
-            "471d8046ab1a48ab9097be929f9f6360",
-            "a8e5a12719314897af9140a1887c1150",
-            "2b4d278c6e8d4a51a8275b55938cd0ad",
-            "fe987a699e484adebca1231b6d03d367",
-            "60a12d6cfdb24aae8c7dcddaad9a3f24",
-            "b6344c56244844669b5d04128557a1ee",
-            "1ac9ec0ead7049688ab26dc09ec6cdfe",
-            "aa00d2f977c2438cb293bafcbcbee6eb"
-          ]
-        },
-        "id": "WaaIKa8dlt5q",
-        "outputId": "4aac7ddd-3c22-4013-a2eb-ae8c618b7d44"
-      },
-      "execution_count": 16,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "  0%|          | 0/3 [00:00<?, ?it/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "ff2d1e780eb441ec8bc910c2dba5da2c"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "2.26"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 16
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "generated_samples_ = torch.stack([random_process() for _ in range(100)])\n",
-        "generated_samples_.mean()"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "NXfZ1J87mFxn",
-        "outputId": "12162ccf-8735-4274-d72a-d762e1d2af2c"
-      },
-      "execution_count": 17,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "tensor(3.9200)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 17
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "torch.square(generated_samples_).mean()"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "TZpCf8eFmQh6",
-        "outputId": "d14d2952-6889-4a8b-f79a-af19cdaeb5c0"
-      },
-      "execution_count": 18,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "tensor(20.5800)"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 18
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Monte Carlo estimation in Pyro"
-      ],
-      "metadata": {
-        "id": "lfVI_FdUoBUI"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import torch\n",
-        "import pyro\n",
-        "from pyro.distributions import Bernoulli, Gamma, Poisson\n",
-        "# This new version of random_process now returns both z and y.\n",
-        "def random_process():\n",
-        "    z = pyro.sample(\"z\", Gamma(7.5, 1.0))\n",
-        "    x = pyro.sample(\"x\", Poisson(z))\n",
-        "    y = torch.tensor(0.0)\n",
-        "    for i in range(int(x)):\n",
-        "        y += pyro.sample(f\"{i}\", Bernoulli(.5))\n",
-        "    return z, y\n",
-        "\n",
-        "# Generate 1000 intances of z and y using a list comprehension.\n",
-        "generated_samples = [random_process() for _ in range(1000)]\n",
-        "# Turn the individual z tensors into a single tensor,\n",
-        "# then calculate the Monte Carlo estimate via the mean method.\n",
-        "z_mean = torch.stack([z for z, _ in generated_samples]).mean()\n",
-        "\n",
-        "print(z_mean)\n",
-        "\n",
-        "z_given_y = torch.stack([z for z, y in generated_samples if y == 3])\n",
-        "\n",
-        "print(z_given_y.mean())\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "U1pve2xmoYAS",
-        "outputId": "8ab89574-64f8-4c58-eeb5-625ffd8b5e3f"
-      },
-      "execution_count": 19,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "tensor(7.4216)\n",
-            "tensor(6.9720)\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "generator.forward_sample(size=10)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 395,
-          "referenced_widgets": [
-            "e3b63a1a0e2446a992feac85a7778977",
-            "7f2c7346c9634edcb8bf5f7bb491471e",
-            "d330ceae733f4dc49ce79057b23bdf0c",
-            "cdf929165c5049a28c99a1de9d31f728",
-            "9213ec21924e4e52ab9d78efa8f390da",
-            "8d0f3c4f6af74b3e9e5c05e1e84f4189",
-            "3adc185fc25348a2ab2e983b47456fca",
-            "6ef7e322bdff42618162b8bc7b8be89b",
-            "f03e769372674f4d83ffdc5da99f12dc",
-            "d6467974ef1e4ead8f2516e1202ebb22",
-            "2ed32b1e8fba4db6b720a80997101185"
-          ]
-        },
-        "id": "sKz_hqByoxHf",
-        "outputId": "c191ee71-0b8a-4624-9344-3a52a1ae7138"
-      },
-      "execution_count": 20,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "  0%|          | 0/3 [00:00<?, ?it/s]"
-            ],
-            "application/vnd.jupyter.widget-view+json": {
-              "version_major": 2,
-              "version_minor": 0,
-              "model_id": "e3b63a1a0e2446a992feac85a7778977"
-            }
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "   Z  X  Y\n",
-              "0  0  0  3\n",
-              "1  0  0  1\n",
-              "2  1  1  3\n",
-              "3  0  0  3\n",
-              "4  0  0  3\n",
-              "5  1  1  1\n",
-              "6  1  0  3\n",
-              "7  0  0  3\n",
-              "8  1  0  2\n",
-              "9  1  0  3"
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-e4b2c2d3-6f67-4458-8856-466a7182ab55\">\n",
-              "    <div class=\"colab-df-container\">\n",
-              "      <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>Z</th>\n",
-              "      <th>X</th>\n",
-              "      <th>Y</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>3</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "      <td>3</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>3</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>3</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>5</th>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>6</th>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>3</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>7</th>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>3</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>8</th>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>2</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>9</th>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>3</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-e4b2c2d3-6f67-4458-8856-466a7182ab55')\"\n",
-              "              title=\"Convert this dataframe to an interactive table.\"\n",
-              "              style=\"display:none;\">\n",
-              "        \n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "       width=\"24px\">\n",
-              "    <path d=\"M0 0h24v24H0V0z\" fill=\"none\"/>\n",
-              "    <path d=\"M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z\"/><path d=\"M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z\"/>\n",
-              "  </svg>\n",
-              "      </button>\n",
-              "      \n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      flex-wrap:wrap;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "      <script>\n",
-              "        const buttonEl =\n",
-              "          document.querySelector('#df-e4b2c2d3-6f67-4458-8856-466a7182ab55 button.colab-df-convert');\n",
-              "        buttonEl.style.display =\n",
-              "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-e4b2c2d3-6f67-4458-8856-466a7182ab55');\n",
-              "          const dataTable =\n",
-              "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                     [key], {});\n",
-              "          if (!dataTable) return;\n",
-              "\n",
-              "          const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "            '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "            + ' to learn more about interactive tables.';\n",
-              "          element.innerHTML = '';\n",
-              "          dataTable['output_type'] = 'display_data';\n",
-              "          await google.colab.output.renderOutput(dataTable, element);\n",
-              "          const docLink = document.createElement('div');\n",
-              "          docLink.innerHTML = docLinkHtml;\n",
-              "          element.appendChild(docLink);\n",
-              "        }\n",
-              "      </script>\n",
-              "    </div>\n",
-              "  </div>\n",
-              "  "
-            ]
-          },
-          "metadata": {},
-          "execution_count": 20
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Generating IID samples in Pyro"
-      ],
-      "metadata": {
-        "id": "aajo3IGGo0Gq"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import pyro\n",
-        "from pyro.distributions import Bernoulli, Poisson, Gamma\n",
-        "\n",
-        "def model():\n",
-        "    z = pyro.sample(\"z\", Gamma(7.5, 1.0))\n",
-        "    x = pyro.sample(\"x\", Poisson(z))\n",
-        "    # pyro.plate is a context manager for generating conditional independent\n",
-        "    # samples. This instance of pyro.plate will generate 10 IID samples.\n",
-        "    with pyro.plate('IID', 10):\n",
-        "        # Calling pyro.sample to generates a single outcome y, where y is a\n",
-        "        # tensor of 10 IID samples.\n",
-        "        y = pyro.sample(\"y\", Bernoulli(x / (5+x)))\n",
-        "    return y\n",
-        "\n",
-        "model()"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "x_v3os5No1Mv",
-        "outputId": "2dbbf447-7fe4-46e9-8676-e2caab6c7c90"
-      },
-      "execution_count": 21,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "tensor([0., 0., 0., 0., 1., 1., 1., 0., 1., 0.])"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 21
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# An example of a data generating process in code form"
-      ],
-      "metadata": {
-        "id": "EZliAGAGpOMO"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def true_dgp(jenny_inclination, brian_inclination, window_strength):    #A\n",
-        "    jenny_throws_rock = jenny_inclination > 0.5    #B\n",
-        "    brian_throws_rock = brian_inclination > 0.5    #B\n",
-        "    if jenny_throws_rock and brian_throws_rock:    #C\n",
-        "        strength_of_impact = 0.8    #C\n",
-        "    elif jenny_throws_rock or brian_throws_rock:    #D\n",
-        "        strength_of_impact = 0.6    #D\n",
-        "    else:    #E\n",
-        "        strength_of_impact = 0.0    #E\n",
-        "    window_breaks = window_strength < strength_of_impact    #F\n",
-        "    return jenny_throws_rock, brian_throws_rock, window_breaks\n",
-        "\n",
-        "#A Input variables reflect Jenny and Brian’s inclination to throw and the window strength.\n",
-        "#B Jenny and Brian throw the rock if so inclined.\n",
-        "#C If both Jenny and Brian throw the rock, the total strength of the impact is .8.\n",
-        "#D If either Jenny or Brian throws the rock, the total strength of the impact is .6.\n",
-        "#E Otherwise, no one throws and the strength of impact is 0.\n",
-        "#F If the strength of impact is greater than the strength of the window, the window breaks.\n",
-        "\n",
-        "initials = [\n",
-        "    (0.6, 0.31, 0.83),\n",
-        "    (0.48, 0.53, 0.33),\n",
-        "    (0.66, 0.63, 0.75),\n",
-        "    (0.65, 0.66, 0.8),\n",
-        "    (0.48, 0.16, 0.27)\n",
-        "]\n",
-        "\n",
-        "data_points = []\n",
-        "for jenny_inclination, brian_inclination, window_strength in initials:    \n",
-        "    data_points.append(\n",
-        "        true_dgp(\n",
-        "            jenny_inclination, brian_inclination, window_strength\n",
-        "        )\n",
-        "    )\n",
-        "\n",
-        "print(data_points)"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "RpuftchRpPUc",
-        "outputId": "aed3b0b0-dd56-486d-9f2b-4f6979e1d0fa"
-      },
-      "execution_count": 22,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[(True, False, False), (False, True, True), (True, True, True), (True, True, False), (False, False, False)]\n"
-          ]
-        }
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: pgmpy==0.1.24 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (0.1.24)\n",
+      "Requirement already satisfied: networkx in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (3.2.1)\n",
+      "Requirement already satisfied: numpy in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (1.26.4)\n",
+      "Requirement already satisfied: scipy in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (1.12.0)\n",
+      "Requirement already satisfied: scikit-learn in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (1.4.0)\n",
+      "Requirement already satisfied: pandas in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (2.2.0)\n",
+      "Requirement already satisfied: pyparsing in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (3.1.1)\n",
+      "Requirement already satisfied: torch in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (2.2.0)\n",
+      "Requirement already satisfied: statsmodels in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (0.14.1)\n",
+      "Requirement already satisfied: tqdm in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (4.66.2)\n",
+      "Requirement already satisfied: joblib in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (1.3.2)\n",
+      "Requirement already satisfied: opt-einsum in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pgmpy==0.1.24) (3.3.0)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pandas->pgmpy==0.1.24) (2.8.2)\n",
+      "Requirement already satisfied: pytz>=2020.1 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pandas->pgmpy==0.1.24) (2024.1)\n",
+      "Requirement already satisfied: tzdata>=2022.7 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pandas->pgmpy==0.1.24) (2023.4)\n",
+      "Requirement already satisfied: threadpoolctl>=2.0.0 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from scikit-learn->pgmpy==0.1.24) (3.2.0)\n",
+      "Requirement already satisfied: patsy>=0.5.4 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from statsmodels->pgmpy==0.1.24) (0.5.6)\n",
+      "Requirement already satisfied: packaging>=21.3 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from statsmodels->pgmpy==0.1.24) (23.2)\n",
+      "Requirement already satisfied: filelock in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch->pgmpy==0.1.24) (3.13.1)\n",
+      "Requirement already satisfied: typing-extensions>=4.8.0 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch->pgmpy==0.1.24) (4.9.0)\n",
+      "Requirement already satisfied: sympy in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch->pgmpy==0.1.24) (1.12)\n",
+      "Requirement already satisfied: jinja2 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch->pgmpy==0.1.24) (3.1.3)\n",
+      "Requirement already satisfied: fsspec in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch->pgmpy==0.1.24) (2024.2.0)\n",
+      "Requirement already satisfied: six in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from patsy>=0.5.4->statsmodels->pgmpy==0.1.24) (1.16.0)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from jinja2->torch->pgmpy==0.1.24) (2.1.5)\n",
+      "Requirement already satisfied: mpmath>=0.19 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from sympy->torch->pgmpy==0.1.24) (1.3.0)\n",
+      "Requirement already satisfied: pyro-ppl==1.8.6 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (1.8.6)\n",
+      "Requirement already satisfied: numpy>=1.7 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pyro-ppl==1.8.6) (1.26.4)\n",
+      "Requirement already satisfied: opt-einsum>=2.3.2 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pyro-ppl==1.8.6) (3.3.0)\n",
+      "Requirement already satisfied: pyro-api>=0.1.1 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pyro-ppl==1.8.6) (0.1.2)\n",
+      "Requirement already satisfied: torch>=1.11.0 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pyro-ppl==1.8.6) (2.2.0)\n",
+      "Requirement already satisfied: tqdm>=4.36 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from pyro-ppl==1.8.6) (4.66.2)\n",
+      "Requirement already satisfied: filelock in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch>=1.11.0->pyro-ppl==1.8.6) (3.13.1)\n",
+      "Requirement already satisfied: typing-extensions>=4.8.0 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch>=1.11.0->pyro-ppl==1.8.6) (4.9.0)\n",
+      "Requirement already satisfied: sympy in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch>=1.11.0->pyro-ppl==1.8.6) (1.12)\n",
+      "Requirement already satisfied: networkx in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch>=1.11.0->pyro-ppl==1.8.6) (3.2.1)\n",
+      "Requirement already satisfied: jinja2 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch>=1.11.0->pyro-ppl==1.8.6) (3.1.3)\n",
+      "Requirement already satisfied: fsspec in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from torch>=1.11.0->pyro-ppl==1.8.6) (2024.2.0)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from jinja2->torch>=1.11.0->pyro-ppl==1.8.6) (2.1.5)\n",
+      "Requirement already satisfied: mpmath>=0.19 in /Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages (from sympy->torch>=1.11.0->pyro-ppl==1.8.6) (1.3.0)\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "# For stability of this notebook, I install the versions of pgmpy and pyro that were current at the time of writing.\n",
+    "!pip install pgmpy==0.1.24\n",
+    "!pip install pyro-ppl==1.8.6"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HcycIJX81Pmm"
+   },
+   "source": [
+    "## Implementing a discrete distribution table in pgmpy\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "qzPPspx4eufQ",
+    "outputId": "c7e9e446-6297-4100-ade1-c0ec0bbc8f6e"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------+----------+\n",
+      "| X    |   phi(X) |\n",
+      "+======+==========+\n",
+      "| X(1) |   0.4500 |\n",
+      "+------+----------+\n",
+      "| X(2) |   0.3000 |\n",
+      "+------+----------+\n",
+      "| X(3) |   0.2500 |\n",
+      "+------+----------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pgmpy\n",
+    "from pgmpy.factors.discrete import DiscreteFactor\n",
+    "dist = DiscreteFactor(\n",
+    "    variables=[\"X\"],    #A\n",
+    "    cardinality=[3],    #B\n",
+    "    values=[.45, .30, .25],    #C\n",
+    "    state_names= {'X': ['1', '2', '3']}    #D\n",
+    ")\n",
+    "\n",
+    "#A A list of the names of the variables in the factor\n",
+    "#B The cardinality (number of possible outcomes of each variable in the factor\n",
+    "#C The values each variable in the factor can take\n",
+    "#D Dictionary where the key is the variable name and the value is a list of the names of that variable’s outcomes\n",
+    "\n",
+    "print(dist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "A-D3GoX4fN52"
+   },
+   "source": [
+    "“phi(X)” is the probability value assigned to each outcome of X.  One thing to note is that these phi values don’t need to sum to one.  For example, I can multiple each probability value by one hundred as follows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "G8bwqFF2fDYb",
+    "outputId": "6c40b86d-6857-4f85-c04f-93df3d3ee951"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------+----------+\n",
+      "| X    |   phi(X) |\n",
+      "+======+==========+\n",
+      "| X(1) |  45.0000 |\n",
+      "+------+----------+\n",
+      "| X(2) |  30.0000 |\n",
+      "+------+----------+\n",
+      "| X(3) |  25.0000 |\n",
+      "+------+----------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "dist = DiscreteFactor(\n",
+    "    variables=[\"X\"],\n",
+    "    cardinality=[3],\n",
+    "    values=[45, 30, 25],\n",
+    "    state_names= {'X': ['1', '2', '3']}\n",
+    ")\n",
+    "\n",
+    "print(dist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tdAVY-hpfa_N"
+   },
+   "source": [
+    "pgmpy relaxes the constraint to sum to one is because the relaxation is useful in some algorithms.  We can always normalize to obtain proper probability values. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "gA1aBQajfZk7",
+    "outputId": "e6574d2a-c34d-4234-e915-d91e7bfb8b4e"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------+----------+\n",
+      "| X    |   phi(X) |\n",
+      "+======+==========+\n",
+      "| X(1) |   0.4500 |\n",
+      "+------+----------+\n",
+      "| X(2) |   0.3000 |\n",
+      "+------+----------+\n",
+      "| X(3) |   0.2500 |\n",
+      "+------+----------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Normalize takes phi values for each outcome and divides them by their sum to get a probability. \n",
+    "dist.normalize()\n",
+    "\n",
+    "print(dist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HDS9Juwtf6tY"
+   },
+   "source": [
+    "## Modeling a joint distribution in pgmpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "TXRN08jSfqCl",
+    "outputId": "c75be905-1d76-456b-8b47-7a3b0e782b19"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------+------+------------+\n",
+      "| X    | Y    |   phi(X,Y) |\n",
+      "+======+======+============+\n",
+      "| X(1) | Y(0) |     0.2500 |\n",
+      "+------+------+------------+\n",
+      "| X(1) | Y(1) |     0.2000 |\n",
+      "+------+------+------------+\n",
+      "| X(2) | Y(0) |     0.2000 |\n",
+      "+------+------+------------+\n",
+      "| X(2) | Y(1) |     0.1000 |\n",
+      "+------+------+------------+\n",
+      "| X(3) | Y(0) |     0.1500 |\n",
+      "+------+------+------------+\n",
+      "| X(3) | Y(1) |     0.1000 |\n",
+      "+------+------+------------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "joint = DiscreteFactor(\n",
+    "    variables=['X', 'Y'],   #A\n",
+    "    cardinality=[3, 2],    #B\n",
+    "    values=[.25, .20, .20, .10, .15, .10],   #C \n",
+    "    state_names= {    \n",
+    "        'X': ['1', '2', '3'],    #C\n",
+    "        'Y': ['0', '1']    #C\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "#A Now we have two variables instead of one.\n",
+    "#B X has 3 outcomes, Y has 2.\n",
+    "#C You can look at the printed output to see how the values are ordered of values.\n",
+    "#D Now there are two variables, so we name the outcomes for both variables.\n",
+    "\n",
+    "print(joint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LmU5Mf5mgO-H"
+   },
+   "source": [
+    "The marginalize method will accomplish summing over the specified variables for us.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "5FQ1-LtqhoRq",
+    "outputId": "db62723e-e123-49df-9653-5e0f5359633c"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------+----------+\n",
+      "| X    |   phi(X) |\n",
+      "+======+==========+\n",
+      "| X(1) |   0.4500 |\n",
+      "+------+----------+\n",
+      "| X(2) |   0.3000 |\n",
+      "+------+----------+\n",
+      "| X(3) |   0.2500 |\n",
+      "+------+----------+\n",
+      "+------+----------+\n",
+      "| Y    |   phi(Y) |\n",
+      "+======+==========+\n",
+      "| Y(0) |   0.6000 |\n",
+      "+------+----------+\n",
+      "| Y(1) |   0.4000 |\n",
+      "+------+----------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(joint.marginalize(variables=['Y'], inplace=False))\n",
+    "print(joint.marginalize(variables=['X'], inplace=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3DQjnxI9ZFaZ"
+   },
+   "source": [
+    "We can use a division operator on two factors to calculate conditional probabilities. Here, P(X, Y)/P(X) = P(Y|X)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "6pHGwacShqn7",
+    "outputId": "3358b982-56fd-4a82-c347-2c0744ab3491"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------+------+------------+\n",
+      "| X    | Y    |   phi(X,Y) |\n",
+      "+======+======+============+\n",
+      "| X(1) | Y(0) |     0.5556 |\n",
+      "+------+------+------------+\n",
+      "| X(1) | Y(1) |     0.4444 |\n",
+      "+------+------+------------+\n",
+      "| X(2) | Y(0) |     0.6667 |\n",
+      "+------+------+------------+\n",
+      "| X(2) | Y(1) |     0.3333 |\n",
+      "+------+------+------------+\n",
+      "| X(3) | Y(0) |     0.6000 |\n",
+      "+------+------+------------+\n",
+      "| X(3) | Y(1) |     0.4000 |\n",
+      "+------+------+------------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(joint / dist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "lNje9Z9IZBY2"
+   },
+   "source": [
+    "However, the more direct way in pgmpy to specify a conditional probability distribution table is with the TabularCPD class:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "4eUC_8dBZPCW",
+    "outputId": "2bc36855-5494-4ff3-c94f-560ce5782953"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+------+--------------------+---------------------+------+\n",
+      "| X    | X(1)               | X(2)                | X(3) |\n",
+      "+------+--------------------+---------------------+------+\n",
+      "| Y(0) | 0.5555555555555556 | 0.6666666666666667  | 0.6  |\n",
+      "+------+--------------------+---------------------+------+\n",
+      "| Y(1) | 0.4444444444444445 | 0.33333333333333337 | 0.4  |\n",
+      "+------+--------------------+---------------------+------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pgmpy.factors.discrete.CPD import TabularCPD\n",
+    "PYgivenX = TabularCPD(\n",
+    "    variable='Y',    #A\n",
+    "    variable_card=2,    #B\n",
+    "    values=[\n",
+    "        [.25/.45, .20/.30, .15/.25],    #C\n",
+    "        [.20/.45, .10/.30, .10/.25],    #C\n",
+    "    ], \n",
+    "    evidence=['X'],\n",
+    "    evidence_card=[3],\n",
+    "    state_names = {\n",
+    "        'X': ['1', '2', '3'],\n",
+    "        'Y': ['0', '1']\n",
+    "    })\n",
+    "\n",
+    "#A Conditional distribution has one variable instead of DiscreteFactor’s list of variables.\n",
+    "#B variable_card is the cardinality of Y\n",
+    "#C Elements of the list correspond to outcomes for Y. Elements of each list correspond to elements of X.\n",
+    "\n",
+    "print(PYgivenX)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FyDHZZDFZy80"
+   },
+   "source": [
+    "## Canonical parameters in Pyro"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "UG_fOPwiZokM",
+    "outputId": "22b119be-e759-499f-a909-bb9049cb99e7"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Categorical(probs: torch.Size([3]))\n",
+      "Normal(loc: 0.0, scale: 1.0)\n",
+      "Bernoulli(probs: 0.4000000059604645)\n",
+      "Gamma(concentration: 1.0, rate: 2.0)\n",
+      "0.3999999887335489\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "from pyro.distributions import Bernoulli, Categorical, Gamma, Normal\n",
+    "\n",
+    "# The categorical distribution takes a list of probability values, each value corresponding to an outcome.\n",
+    "print(Categorical(probs=torch.tensor([.45, .30, .25])))\n",
+    "print(Normal(loc=0.0, scale=1.0))\n",
+    "print(Bernoulli(probs=0.4))\n",
+    "print(Gamma(concentration=1.0, rate=2.0))\n",
+    "\n",
+    "bern = Bernoulli(0.4)\n",
+    "lprob = bern.log_prob(torch.tensor(1.0))\n",
+    "\n",
+    "import math\n",
+    "print(math.exp(lprob))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4sKd5PbLbvtu"
+   },
+   "source": [
+    "## Simulating from DiscreteFactor in pgmpy and Pyro"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 81
+    },
+    "id": "lOqDNVM8buUH",
+    "outputId": "76780e33-64d5-4dfd-937f-4f0dad0480eb"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>X</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   X\n",
+       "0  1\n",
+       "1  1\n",
+       "2  2"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pgmpy.factors.discrete import DiscreteFactor\n",
+    "dist = DiscreteFactor(\n",
+    "    variables=[\"X\"],\n",
+    "    cardinality=[3],\n",
+    "    values=[.45, .30, .25],\n",
+    "    state_names= {'X': ['1', '2', '3']}\n",
+    ")\n",
+    "\n",
+    "# n is the number of instances you wish to generate\n",
+    "dist.sample(n=3)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 81
+    },
+    "id": "3gFe94BJb904",
+    "outputId": "ef28fd3f-572c-4078-abea-7c9a581ad579"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>X</th>\n",
+       "      <th>Y</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   X  Y\n",
+       "0  2  1\n",
+       "1  1  0\n",
+       "2  3  1"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "joint = DiscreteFactor(\n",
+    "    variables=['X', 'Y'],\n",
+    "    cardinality=[3, 2],\n",
+    "    values=[.25, .20, .20, .10, .15, .10],\n",
+    "    state_names= {\n",
+    "        'X': ['1', '2', '3'],\n",
+    "        'Y': ['0', '1']\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "joint.sample(n=3)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jL-oWJuRcNFI"
+   },
+   "source": [
+    "Canonical distributions in pyro also use a method with sample method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "LvvQ_jv1cJLZ",
+    "outputId": "41e6e552-3a8b-4d6c-f758-4dd9cf91361e"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor(0)\n",
+      "tensor([0, 1, 2, 2, 1, 0, 2, 1, 1, 1])\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "from pyro.distributions import Categorical\n",
+    "# Generate 1 sample\n",
+    "one_sample = Categorical(probs=torch.tensor([.45, .30, .25])).sample()\n",
+    "print(one_sample)\n",
+    "# Generate 10 samples\n",
+    "samples = Categorical(probs=torch.tensor([.45, .30, .25])).sample(sample_shape=torch.Size([10]))\n",
+    "print(samples)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MtP49-FcdZ0G"
+   },
+   "source": [
+    "## Creating a random process in pgmpy and pyro."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 113,
+     "referenced_widgets": [
+      "e3d150d5dd434fee8b44c8234ca6f0bb",
+      "ab7cefa9ca604bd1875aac6af7ee80d6",
+      "03523d6eaab149659f1f940c746c1a1a",
+      "8687a49bb8454f0592c80a26b3197b83",
+      "b9f872f2e69a4d52a6bc5a35eb65f8cb",
+      "6de980a54d33458cad46a859ddd9827b",
+      "54b15c7e8a004d70ac43f0d671259a70",
+      "d7aeb5ae6cab45299006a8edb58b0e5a",
+      "16f74741d4af4d36a79f319d9e800ee4",
+      "4ae256d707414f999cd8db3cce2b7e86",
+      "b0c5861eb58341848f7a09f8bb429f9d"
+     ]
+    },
+    "id": "ix9uF77qcW-D",
+    "outputId": "d43b9877-6843-4c1a-be82-fcab6acf8c8a"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f787afa51bab45d8a4481e2c6dbca06b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/3 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages/pgmpy/sampling/base.py:582: FutureWarning: Passing a DataFrame to DataFrame.from_records is deprecated. Use set_index and/or drop to modify the DataFrame instead.\n",
+      "  df = pd.DataFrame.from_records(samples)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Z</th>\n",
+       "      <th>X</th>\n",
+       "      <th>Y</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Z  X  Y\n",
+       "0  0  0  3\n",
+       "1  0  0  3\n",
+       "2  0  0  2"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pgmpy.factors.discrete.CPD import TabularCPD\n",
+    "from pgmpy.models import BayesianNetwork\n",
+    "from pgmpy.sampling import BayesianModelSampling\n",
+    "\n",
+    "# Values is the probability value assigned to each outcome. The\n",
+    "PZ = TabularCPD(\n",
+    "    variable='Z', \n",
+    "    variable_card=2,\n",
+    "    values=[[.65], [.35]],\n",
+    "    state_names = {\n",
+    "        'Z': ['0', '1']\n",
+    "    })\n",
+    "\n",
+    "# The probability values map to the outcomes specified in the state_names argument.\n",
+    "PXgivenZ = TabularCPD(\n",
+    "    variable='X',\n",
+    "    variable_card=2,\n",
+    "    values=[\n",
+    "        [.8, .6],\n",
+    "        [.2, .4],\n",
+    "    ],\n",
+    "    evidence=['Z'],\n",
+    "    evidence_card=[2],\n",
+    "    state_names = {\n",
+    "        'X': ['0', '1'],\n",
+    "        'Z': ['0', '1']\n",
+    "    })\n",
+    "\n",
+    "PYgivenX = TabularCPD(\n",
+    "    variable='Y',\n",
+    "    variable_card=3,\n",
+    "    values=[\n",
+    "        [.1, .8],\n",
+    "        [.2, .1],\n",
+    "        [.7, .1],\n",
+    "    ],\n",
+    "    evidence=['X'],\n",
+    "    evidence_card=[2],\n",
+    "    state_names = {\n",
+    "        'Y': ['1', '2', '3'],\n",
+    "        'X': ['0', '1']\n",
+    "    })\n",
+    "\n",
+    "model = BayesianNetwork([('Z', 'X'), ('X', 'Y')])\n",
+    "model.add_cpds(PZ, PXgivenZ, PYgivenX)\n",
+    "\n",
+    "generator = BayesianModelSampling(model)\n",
+    "generator.forward_sample(size=3)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Mx1_KI7AdOsm"
+   },
+   "source": [
+    "# Working with combinations of canonical distributions in Pyro"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "92aWaC4qhcv0",
+    "outputId": "796c3444-b7da-4b4d-96f8-7f11018a07f2"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor(7.2970) tensor(6.) tensor(0.)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "from pyro.distributions import Bernoulli, Poisson, Gamma\n",
+    "\n",
+    "# Represent P(Z) with a Gamma distribution, and sample z.\n",
+    "z = Gamma(7.5, 1.0).sample()    #A\n",
+    "# Represent P(X|Z=z) with a Poisson distribution with location parameter z, and sample x.\n",
+    "x = Poisson(z).sample()    #B\n",
+    "# Represent P(Y|X=x) with a Bernoulli distribution. The probability parameter is a function of y.\n",
+    "y = Bernoulli(x / (5+x)).sample()    #C\n",
+    "\n",
+    "print(z, x, y)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4eYUHJFUj7cp"
+   },
+   "source": [
+    "# Random processes with nuanced control flow in Pyro"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "id": "IrGBg5gYj80N"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor(8.5513) tensor(10.) tensor(6.)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "from pyro.distributions import Bernoulli, Poisson, Gamma\n",
+    "z = Gamma(7.5, 1.0).sample()\n",
+    "x = Poisson(z).sample()\n",
+    "# y is calculated as a sum of random coin flips.\n",
+    "# y is generated from P(Y|X=x) because the number of flips depends on x.\n",
+    "y = torch.tensor(0.0)\n",
+    "for i in range(int(x)):\n",
+    "    y += Bernoulli(.5).sample()    \n",
+    "print(z, x, y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "t9apo5zPlsz-"
+   },
+   "source": [
+    "# Using functions for random processes and pyro.sample\n",
+    "\n",
+    "In the code below, we generate multiple samples and then use the `mean` method to calculate an average of those samples."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 67,
+     "referenced_widgets": [
+      "ff2d1e780eb441ec8bc910c2dba5da2c",
+      "78cffc8c3acc4c7a9f062bab35547ab0",
+      "39ceb682850d4efea7bfbeaf81f2178d",
+      "471d8046ab1a48ab9097be929f9f6360",
+      "a8e5a12719314897af9140a1887c1150",
+      "2b4d278c6e8d4a51a8275b55938cd0ad",
+      "fe987a699e484adebca1231b6d03d367",
+      "60a12d6cfdb24aae8c7dcddaad9a3f24",
+      "b6344c56244844669b5d04128557a1ee",
+      "1ac9ec0ead7049688ab26dc09ec6cdfe",
+      "aa00d2f977c2438cb293bafcbcbee6eb"
+     ]
+    },
+    "id": "WaaIKa8dlt5q",
+    "outputId": "4aac7ddd-3c22-4013-a2eb-ae8c618b7d44"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6ab42668be9c4de4b432302d87808b69",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/3 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages/pgmpy/sampling/base.py:582: FutureWarning: Passing a DataFrame to DataFrame.from_records is deprecated. Use set_index and/or drop to modify the DataFrame instead.\n",
+      "  df = pd.DataFrame.from_records(samples)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2.2"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import pyro\n",
+    "def random_process():\n",
+    "    z = pyro.sample(\"z\", Gamma(7.5, 1.0))\n",
+    "    x = pyro.sample(\"x\", Poisson(z))\n",
+    "    y = torch.tensor(0.0)\n",
+    "    for i in range(int(x)):\n",
+    "        y += pyro.sample(f\"y{i}\", Bernoulli(.5))    #A\n",
+    "    return y\n",
+    "\n",
+    "generated_samples = generator.forward_sample(size=100)\n",
+    "generated_samples['Y'].apply(int).mean()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "NXfZ1J87mFxn",
+    "outputId": "12162ccf-8735-4274-d72a-d762e1d2af2c"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor(3.9900)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generated_samples_ = torch.stack([random_process() for _ in range(100)])\n",
+    "generated_samples_.mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "TZpCf8eFmQh6",
+    "outputId": "d14d2952-6889-4a8b-f79a-af19cdaeb5c0"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor(22.8900)"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torch.square(generated_samples_).mean()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "lfVI_FdUoBUI"
+   },
+   "source": [
+    "# Monte Carlo estimation in Pyro"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "U1pve2xmoYAS",
+    "outputId": "8ab89574-64f8-4c58-eeb5-625ffd8b5e3f"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tensor(7.5682)\n",
+      "tensor(7.1242)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "import pyro\n",
+    "from pyro.distributions import Bernoulli, Gamma, Poisson\n",
+    "# This new version of random_process now returns both z and y.\n",
+    "def random_process():\n",
+    "    z = pyro.sample(\"z\", Gamma(7.5, 1.0))\n",
+    "    x = pyro.sample(\"x\", Poisson(z))\n",
+    "    y = torch.tensor(0.0)\n",
+    "    for i in range(int(x)):\n",
+    "        y += pyro.sample(f\"{i}\", Bernoulli(.5))\n",
+    "    return z, y\n",
+    "\n",
+    "# Generate 1000 instances of z and y using a list comprehension.\n",
+    "generated_samples = [random_process() for _ in range(1000)]\n",
+    "# Turn the individual z tensors into a single tensor,\n",
+    "# then calculate the Monte Carlo estimate via the mean method.\n",
+    "z_mean = torch.stack([z for z, _ in generated_samples]).mean()\n",
+    "\n",
+    "print(z_mean)\n",
+    "\n",
+    "z_given_y = torch.stack([z for z, y in generated_samples if y == 3])\n",
+    "\n",
+    "print(z_given_y.mean())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 395,
+     "referenced_widgets": [
+      "e3b63a1a0e2446a992feac85a7778977",
+      "7f2c7346c9634edcb8bf5f7bb491471e",
+      "d330ceae733f4dc49ce79057b23bdf0c",
+      "cdf929165c5049a28c99a1de9d31f728",
+      "9213ec21924e4e52ab9d78efa8f390da",
+      "8d0f3c4f6af74b3e9e5c05e1e84f4189",
+      "3adc185fc25348a2ab2e983b47456fca",
+      "6ef7e322bdff42618162b8bc7b8be89b",
+      "f03e769372674f4d83ffdc5da99f12dc",
+      "d6467974ef1e4ead8f2516e1202ebb22",
+      "2ed32b1e8fba4db6b720a80997101185"
+     ]
+    },
+    "id": "sKz_hqByoxHf",
+    "outputId": "c191ee71-0b8a-4624-9344-3a52a1ae7138"
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8655ae1f9ae346cd9581ffc018476753",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/3 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/robertness/Dropbox/code/causalML/book/venv/lib/python3.11/site-packages/pgmpy/sampling/base.py:582: FutureWarning: Passing a DataFrame to DataFrame.from_records is deprecated. Use set_index and/or drop to modify the DataFrame instead.\n",
+      "  df = pd.DataFrame.from_records(samples)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Z</th>\n",
+       "      <th>X</th>\n",
+       "      <th>Y</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Z  X  Y\n",
+       "0  0  0  3\n",
+       "1  0  0  3\n",
+       "2  0  0  3\n",
+       "3  1  1  1\n",
+       "4  0  0  3\n",
+       "5  0  0  3\n",
+       "6  0  0  3\n",
+       "7  1  0  1\n",
+       "8  1  0  2\n",
+       "9  1  0  3"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "generator.forward_sample(size=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aajo3IGGo0Gq"
+   },
+   "source": [
+    "# Generating IID samples in Pyro"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "x_v3os5No1Mv",
+    "outputId": "2dbbf447-7fe4-46e9-8676-e2caab6c7c90"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([1., 0., 1., 0., 0., 0., 0., 1., 1., 0.])"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pyro\n",
+    "from pyro.distributions import Bernoulli, Poisson, Gamma\n",
+    "\n",
+    "def model():\n",
+    "    z = pyro.sample(\"z\", Gamma(7.5, 1.0))\n",
+    "    x = pyro.sample(\"x\", Poisson(z))\n",
+    "    # pyro.plate is a context manager for generating conditional independent\n",
+    "    # samples. This instance of pyro.plate will generate 10 IID samples.\n",
+    "    with pyro.plate('IID', 10):\n",
+    "        # Calling pyro.sample to generates a single outcome y, where y is a\n",
+    "        # tensor of 10 IID samples.\n",
+    "        y = pyro.sample(\"y\", Bernoulli(x / (5+x)))\n",
+    "    return y\n",
+    "\n",
+    "model()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EZliAGAGpOMO"
+   },
+   "source": [
+    "# An example of a data generating process in code form"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "RpuftchRpPUc",
+    "outputId": "aed3b0b0-dd56-486d-9f2b-4f6979e1d0fa"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(True, False, False), (False, True, True), (True, True, True), (True, True, False), (False, False, False)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "def true_dgp(jenny_inclination, brian_inclination, window_strength):    #A\n",
+    "    jenny_throws_rock = jenny_inclination > 0.5    #B\n",
+    "    brian_throws_rock = brian_inclination > 0.5    #B\n",
+    "    if jenny_throws_rock and brian_throws_rock:    #C\n",
+    "        strength_of_impact = 0.8    #C\n",
+    "    elif jenny_throws_rock or brian_throws_rock:    #D\n",
+    "        strength_of_impact = 0.6    #D\n",
+    "    else:    #E\n",
+    "        strength_of_impact = 0.0    #E\n",
+    "    window_breaks = window_strength < strength_of_impact    #F\n",
+    "    return jenny_throws_rock, brian_throws_rock, window_breaks\n",
+    "\n",
+    "#A Input variables reflect Jenny and Brian’s inclination to throw and the window strength.\n",
+    "#B Jenny and Brian throw the rock if so inclined.\n",
+    "#C If both Jenny and Brian throw the rock, the total strength of the impact is .8.\n",
+    "#D If either Jenny or Brian throws the rock, the total strength of the impact is .6.\n",
+    "#E Otherwise, no one throws and the strength of impact is 0.\n",
+    "#F If the strength of impact is greater than the strength of the window, the window breaks.\n",
+    "\n",
+    "initials = [\n",
+    "    (0.6, 0.31, 0.83),\n",
+    "    (0.48, 0.53, 0.33),\n",
+    "    (0.66, 0.63, 0.75),\n",
+    "    (0.65, 0.66, 0.8),\n",
+    "    (0.48, 0.16, 0.27)\n",
+    "]\n",
+    "\n",
+    "data_points = []\n",
+    "# Now we pass each tuple in the initials list as an input to the true_dgp function, generate a data point, and add this to the data_points list. \n",
+    "for jenny_inclination, brian_inclination, window_strength in initials:    \n",
+    "    data_points.append(\n",
+    "        true_dgp(\n",
+    "            jenny_inclination, brian_inclination, window_strength\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "print(data_points)"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.1"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "03523d6eaab149659f1f940c746c1a1a": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_d7aeb5ae6cab45299006a8edb58b0e5a",
+      "max": 3,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_16f74741d4af4d36a79f319d9e800ee4",
+      "value": 3
+     }
+    },
+    "16f74741d4af4d36a79f319d9e800ee4": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "1ac9ec0ead7049688ab26dc09ec6cdfe": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "2b4d278c6e8d4a51a8275b55938cd0ad": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "2ed32b1e8fba4db6b720a80997101185": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "39ceb682850d4efea7bfbeaf81f2178d": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_60a12d6cfdb24aae8c7dcddaad9a3f24",
+      "max": 3,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_b6344c56244844669b5d04128557a1ee",
+      "value": 3
+     }
+    },
+    "3adc185fc25348a2ab2e983b47456fca": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "471d8046ab1a48ab9097be929f9f6360": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_1ac9ec0ead7049688ab26dc09ec6cdfe",
+      "placeholder": "​",
+      "style": "IPY_MODEL_aa00d2f977c2438cb293bafcbcbee6eb",
+      "value": " 3/3 [00:00&lt;00:00, 30.00it/s]"
+     }
+    },
+    "4ae256d707414f999cd8db3cce2b7e86": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "54b15c7e8a004d70ac43f0d671259a70": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "60a12d6cfdb24aae8c7dcddaad9a3f24": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "6de980a54d33458cad46a859ddd9827b": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "6ef7e322bdff42618162b8bc7b8be89b": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "78cffc8c3acc4c7a9f062bab35547ab0": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_2b4d278c6e8d4a51a8275b55938cd0ad",
+      "placeholder": "​",
+      "style": "IPY_MODEL_fe987a699e484adebca1231b6d03d367",
+      "value": "Generating for node: Y: 100%"
+     }
+    },
+    "7f2c7346c9634edcb8bf5f7bb491471e": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_8d0f3c4f6af74b3e9e5c05e1e84f4189",
+      "placeholder": "​",
+      "style": "IPY_MODEL_3adc185fc25348a2ab2e983b47456fca",
+      "value": "Generating for node: Y: 100%"
+     }
+    },
+    "8687a49bb8454f0592c80a26b3197b83": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_4ae256d707414f999cd8db3cce2b7e86",
+      "placeholder": "​",
+      "style": "IPY_MODEL_b0c5861eb58341848f7a09f8bb429f9d",
+      "value": " 3/3 [00:00&lt;00:00,  7.24it/s]"
+     }
+    },
+    "8d0f3c4f6af74b3e9e5c05e1e84f4189": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "9213ec21924e4e52ab9d78efa8f390da": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "a8e5a12719314897af9140a1887c1150": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "aa00d2f977c2438cb293bafcbcbee6eb": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "ab7cefa9ca604bd1875aac6af7ee80d6": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_6de980a54d33458cad46a859ddd9827b",
+      "placeholder": "​",
+      "style": "IPY_MODEL_54b15c7e8a004d70ac43f0d671259a70",
+      "value": "Generating for node: Y: 100%"
+     }
+    },
+    "b0c5861eb58341848f7a09f8bb429f9d": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "b6344c56244844669b5d04128557a1ee": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "b9f872f2e69a4d52a6bc5a35eb65f8cb": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "cdf929165c5049a28c99a1de9d31f728": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_d6467974ef1e4ead8f2516e1202ebb22",
+      "placeholder": "​",
+      "style": "IPY_MODEL_2ed32b1e8fba4db6b720a80997101185",
+      "value": " 3/3 [00:00&lt;00:00, 36.60it/s]"
+     }
+    },
+    "d330ceae733f4dc49ce79057b23bdf0c": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_6ef7e322bdff42618162b8bc7b8be89b",
+      "max": 3,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_f03e769372674f4d83ffdc5da99f12dc",
+      "value": 3
+     }
+    },
+    "d6467974ef1e4ead8f2516e1202ebb22": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "d7aeb5ae6cab45299006a8edb58b0e5a": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "e3b63a1a0e2446a992feac85a7778977": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_7f2c7346c9634edcb8bf5f7bb491471e",
+       "IPY_MODEL_d330ceae733f4dc49ce79057b23bdf0c",
+       "IPY_MODEL_cdf929165c5049a28c99a1de9d31f728"
+      ],
+      "layout": "IPY_MODEL_9213ec21924e4e52ab9d78efa8f390da"
+     }
+    },
+    "e3d150d5dd434fee8b44c8234ca6f0bb": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_ab7cefa9ca604bd1875aac6af7ee80d6",
+       "IPY_MODEL_03523d6eaab149659f1f940c746c1a1a",
+       "IPY_MODEL_8687a49bb8454f0592c80a26b3197b83"
+      ],
+      "layout": "IPY_MODEL_b9f872f2e69a4d52a6bc5a35eb65f8cb"
+     }
+    },
+    "f03e769372674f4d83ffdc5da99f12dc": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "fe987a699e484adebca1231b6d03d367": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "ff2d1e780eb441ec8bc910c2dba5da2c": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_78cffc8c3acc4c7a9f062bab35547ab0",
+       "IPY_MODEL_39ceb682850d4efea7bfbeaf81f2178d",
+       "IPY_MODEL_471d8046ab1a48ab9097be929f9f6360"
+      ],
+      "layout": "IPY_MODEL_a8e5a12719314897af9140a1887c1150"
+     }
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
> In Chapter_2_Primer_on_Probability_Modeling.ipynb
> 	I get a warning of type: INFO:numexpr.utils:Note: NumExpr detected 16 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 8.
> INFO:numexpr.utils:NumExpr defaulting to 8 threads.
> 	Maybe it might be somehow avoided. See for ex https://stackoverflow.com/questions/71248521/why-numexpr-defaulting-to-8-threads-warning-message-shown-in-python
> 

I am unable to reproduce in my local virtual environment.
	

> 	under MD cell w/  "We can divide two factors to calculate conditional probabilities.": print(joint / dist) # it might be usefull to add that the prited distribution is $P(Y|X)$

Done

> 	under MD cell "However, the more direct way in pgmpy to specify a conditional probability distribution table is with the TabularCPD class:", you umight want to add that for lines #C the denomiators are the marginal values $P(X)$, for all 3 values of X. 

Clarified

> 	under MD cell "## Simulating from DiscreteFactor in pgmpy and Pyro", you  might want to draw ultiple samples, to show the variability of the results. same for other sampling examples

Done.
	

> 	in  cell under MD header ## Creating a random process in pgmpy and pyro.: it might be of help to show what the param "values" is storing, as comment. For example, in 
> 	PXgivenZ = TabularCPD(
>     variable='X',
>     variable_card=2,
>     values=[
>         [.8, .6],
>         [.2, .4],
>     ],
>     evidence=['Z'],
>     evidence_card=[2],
>     state_names = {
>         'X': ['0', '1'],
>         'Z': ['0', '1']
>     })
> 	I am not sure what oon the interpretation of the 2x2 matrix for "values"

Clarified.

> 	In the same cell: there are 2 lines commented as #D and #F (but no # A, #B, etc - srange). There are no comments  associated with #D and #F. They are seen in word doc, but not here. One should kee the book and code in sync 

Clarified.

> 	For the same cell: I get a warning, 
> 		"/home/lucian/anaconda3/envs/causal_manning/lib/python3.11/site-packages/pgmpy/sampling/base.py:582: FutureWarning: Passing a DataFrame to DataFrame.from_records is deprecated. Use set_index and/or drop to modify the DataFrame instead.
>   df = pd.DataFrame.from_records(samples)".
>   Maybe you should update the code. 
>   The same warning for cell code under MD cell w/ "# Using functions for random processes and pyro.sample "

The FutureWarnings are an issue with how pgmpy works with pandas internally. I can't fix this as a user  of pgmpy

>   in code cell under MD cell w/ "# Random processes with nuanced control flow in Pyro": add a print(y) at the end to see what you got.

Done.
  

>   for cell w/ code generated_samples_.mean() - please tell the reader what it's done here

Done.
  

>   in code cell under "# Monte Carlo estimation in Pyro": typo intances

Fixed.
  

>   in code cell under "# An example of a data generating process in code form", one can find comments # A, # B.. # F but no other commment added. Can you add these as well?
 
Added comments.